### PR TITLE
Upgrade to Elixir 1.2 (HashDict -> Map)

### DIFF
--- a/lib/ogma.ex
+++ b/lib/ogma.ex
@@ -2,7 +2,7 @@ defmodule Ogma do
   use GenServer
 
   defmodule State do
-    defstruct pid_to_topics: HashDict.new
+    defstruct pid_to_topics: Map.new
   end
 
   def start_link() do
@@ -32,13 +32,13 @@ defmodule Ogma do
         {:stop, error, s}
       pids ->
         unless pid in pids do
-          case HashDict.fetch(s.pid_to_topics, pid) do
+          case Map.fetch(s.pid_to_topics, pid) do
             {:ok, topics} ->
               :pg2.join(topic, pid)
-              {:reply, :ok, %{s | pid_to_topics: HashDict.put(s.pid_to_topics, pid, [topic|topics])}}
+              {:reply, :ok, %{s | pid_to_topics: Map.put(s.pid_to_topics, pid, [topic|topics])}}
             :error ->
               :pg2.join(topic, pid)
-              {:reply, :ok, %{s | pid_to_topics: HashDict.put(s.pid_to_topics, pid,[topic])}}
+              {:reply, :ok, %{s | pid_to_topics: Map.put(s.pid_to_topics, pid,[topic])}}
           end
       end
     end
@@ -49,13 +49,13 @@ defmodule Ogma do
       {:error, _} ->
         {:noreply, s}
       :ok ->
-        case HashDict.fetch(s.pid_to_topics, pid) do
+        case Map.fetch(s.pid_to_topics, pid) do
           {:ok, topics} ->
             case List.delete(topics, topic) do
               [] ->
-                {:noreply, %{s | pid_to_topics: HashDict.drop(s.pid_to_topics, [pid])}}
+                {:noreply, %{s | pid_to_topics: Map.drop(s.pid_to_topics, [pid])}}
               topics ->
-                {:noreply, %{s | pid_to_topics: HashDict.put(s.pid_to_topics, pid, topics)}}
+                {:noreply, %{s | pid_to_topics: Map.put(s.pid_to_topics, pid, topics)}}
             end
           :error ->
             {:noreply, s}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ogma.Mixfile do
   def project do
     [app: :ogma,
      version: "0.0.1",
-     elixir: "~> 1.0",
+     elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps]


### PR DESCRIPTION
- Elixir 1.2 rely on Erlang 18, so we can use Maps instead of HashDict for storing massive amounts of key-values. I've replaced all the HashDicts with Maps
- Updated the Elixir version in the mix-file
