### PR TITLE
Fixing indentation issue in publish

### DIFF
--- a/lib/ogma.ex
+++ b/lib/ogma.ex
@@ -68,10 +68,8 @@ defmodule Ogma do
       {:error, _} ->
         {:noreply, s}
       pids ->
-        for pid <- pids do
-          send(pid, message)
-      end #@todo: report indentation error on alchemist
-         {:noreply, s}
+        for pid <- pids, do: send(pid, message)
+        {:noreply, s}
     end
   end
 


### PR DESCRIPTION
I saw your comment about the failing indentation with for-comprehensions in case-blocks, and I've gone ahead and reported the issue to emacs-elixir (it is in emacs-mode, not alchemist). I've provided them with a failing unit test so it should get fixed in an upcoming version of the major-mode.

Follow the issue here: https://github.com/elixir-lang/emacs-elixir/issues/304
